### PR TITLE
Feature/find ticket numbers between builds inf 317

### DIFF
--- a/Bluewire.Common.GitWrapper/Model/RefHelper.cs
+++ b/Bluewire.Common.GitWrapper/Model/RefHelper.cs
@@ -35,6 +35,12 @@ namespace Bluewire.Common.GitWrapper.Model
             return new Ref($"refs/{hierarchyName}/{@ref}");
         }
 
+        public static Ref GetRemoteRef(Ref @ref, string remoteHierarchy = "origin")
+        {
+            if (IsInHierarchy(remoteHierarchy, @ref)) return @ref;
+            return new Ref($"{remoteHierarchy}/{@ref}");
+        }
+
         /// <summary>
         /// If the ref is in the specified hierarchy, remove the 'refs/X' part.
         /// If the ref is not in the specified hierarchy, throws an ArgumentException because

--- a/Bluewire.Common.GitWrapper/Model/RefHelper.cs
+++ b/Bluewire.Common.GitWrapper/Model/RefHelper.cs
@@ -30,9 +30,21 @@ namespace Bluewire.Common.GitWrapper.Model
 
         public static Ref PutInHierarchy(string hierarchyName, Ref @ref)
         {
-            if (IsInHierarchy(hierarchyName, @ref)) return @ref;
-            if (@ref.ToString().StartsWith("refs/")) throw new ArgumentException($"Ref '{@ref}' is already qualified. Cannot prefix with 'refs/{hierarchyName}/'.");
+            if (IsInHierarchy(hierarchyName, @ref)) return EnsureFullyQualifed(hierarchyName, @ref);
+            if (IsFullyQualifed(@ref)) throw new ArgumentException($"Ref '{@ref}' is already qualified. Cannot prefix with 'refs/{hierarchyName}/'.");
             return new Ref($"refs/{hierarchyName}/{@ref}");
+        }
+
+        public static bool IsFullyQualifed(Ref @ref)
+        {
+            return @ref.ToString().StartsWith("refs/");
+        }
+
+        private static Ref EnsureFullyQualifed(string hierarchyName, Ref @ref)
+        {
+            if (IsFullyQualifed(@ref)) return @ref;
+            if (IsInHierarchy(hierarchyName, @ref)) return new Ref($"refs/{@ref}");
+            throw new ArgumentException($"Ref '{@ref}' is not in the specified hierarchy: {hierarchyName}.");
         }
 
         public static Ref GetRemoteRef(Ref @ref, string remoteHierarchy = "origin")

--- a/Bluewire.Conventions.UnitTests/Bluewire.Conventions.UnitTests.csproj
+++ b/Bluewire.Conventions.UnitTests/Bluewire.Conventions.UnitTests.csproj
@@ -44,6 +44,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BranchSemanticsTests.cs" />
+    <Compile Include="SemanticVersionTests.cs" />
     <Compile Include="StructuredBranchTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Bluewire.Conventions.UnitTests/BranchSemanticsTests.cs
+++ b/Bluewire.Conventions.UnitTests/BranchSemanticsTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Bluewire.Conventions.UnitTests
+{
+    [TestFixture]
+    public class BranchSemanticsTests
+    {
+        public struct Case
+        {
+            public string Raw { get; set; }
+            public SemanticVersion Parsed { get; set; }
+            public string BranchStart { get; set; }
+            public string BranchEnd { get; set; }
+
+            public override string ToString()
+            {
+                return Raw;
+            }
+        }
+        
+        public static Case[] Cases = {
+            new Case { Raw = "17.05.123-beta", Parsed = new SemanticVersion("17","05",123,"beta"), BranchStart = "17.05", BranchEnd = "master" },
+            new Case { Raw = "17.05.123-rc", Parsed = new SemanticVersion("17","05",123,"rc"), BranchStart = "17.05", BranchEnd = "candidate/17.05" },
+            new Case { Raw = "17.05.123-canary", Parsed = new SemanticVersion("17","05",123,"canary"), BranchStart = "17.05", BranchEnd = null },
+            new Case { Raw = "17.05.123-release", Parsed = new SemanticVersion("17","05",123,"release"), BranchStart = "17.05", BranchEnd = "release/17.05" }
+        };
+        
+        [Test]
+        public void CanIdentifyStartOfBranch([ValueSource(nameof(Cases))] Case testCase)
+        {
+            var sut = new BranchSemantics();
+            var parsed = SemanticVersion.FromString(testCase.Raw);
+            Assert.That(sut.GetVersionZeroBranchName(parsed), Is.EqualTo(testCase.BranchStart));
+            Assert.That(sut.GetVersionLatestBranchName(parsed), Is.EqualTo(testCase.BranchEnd));
+        }
+
+        [Test]
+        public void ThrowsExceptionIfSemTagIsMissing()
+        {
+            var sut = new BranchSemantics();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var semVer = new SemanticVersion("17", "05", 123, null);
+                sut.GetVersionLatestBranchName(semVer);
+            });
+        }
+
+        [Test]
+        public void ThrowsExceptionIfSemTagIsEmpty()
+        {
+            var sut = new BranchSemantics();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var semVer = new SemanticVersion("17", "05", 123, "");
+                sut.GetVersionLatestBranchName(semVer);
+            });
+        }
+
+        [Test]
+        public void ThrowsExceptionIfSemTagIsUnknown()
+        {
+            var sut = new BranchSemantics();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var semVer = new SemanticVersion("17", "05", 123, "unknownsemtagfortesting");
+                sut.GetVersionLatestBranchName(semVer);
+            });
+        }
+    }
+}

--- a/Bluewire.Conventions.UnitTests/SemanticVersionTests.cs
+++ b/Bluewire.Conventions.UnitTests/SemanticVersionTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+
+namespace Bluewire.Conventions.UnitTests
+{
+    [TestFixture]
+    public class SemanticVersionTests
+    {
+        public struct Case
+        {
+            public string Raw { get; set; }
+            public SemanticVersion Parsed { get; set; }
+
+            public override string ToString()
+            {
+                return Raw;
+            }
+        }
+        
+        public static Case[] Cases = {
+            new Case { Raw = "17.05.123-beta", Parsed = new SemanticVersion("17","05",123,"beta") },
+            new Case { Raw = "17.05.123-rc", Parsed = new SemanticVersion("17","05",123,"rc") },
+            new Case { Raw = "17.05.123-canary", Parsed = new SemanticVersion("17","05",123,"canary") },
+            new Case { Raw = "17.05.123-release", Parsed = new SemanticVersion("17","05",123,"release") }
+        };
+        
+        [Test]
+        public void CanParse([ValueSource(nameof(Cases))] Case testCase)
+        {
+            var parsed = SemanticVersion.FromString(testCase.Raw);
+            Assert.That(parsed.Major, Is.EqualTo(testCase.Parsed.Major));
+            Assert.That(parsed.Minor, Is.EqualTo(testCase.Parsed.Minor));
+            Assert.That(parsed.Build, Is.EqualTo(testCase.Parsed.Build));
+            Assert.That(parsed.SemanticTag, Is.EqualTo(testCase.Parsed.SemanticTag));
+        }
+      
+        [Test]
+        public void CanFormat([ValueSource(nameof(Cases))] Case testCase)
+        {
+            Assert.That(testCase.Parsed.ToString(), Is.EqualTo(testCase.Raw));
+        }
+    }
+}

--- a/Bluewire.Conventions/Bluewire.Conventions.csproj
+++ b/Bluewire.Conventions/Bluewire.Conventions.csproj
@@ -44,6 +44,7 @@
     <Compile Include="BranchSemantics.cs" />
     <Compile Include="BranchType.cs" />
     <Compile Include="Patterns.cs" />
+    <Compile Include="SemanticVersion.cs" />
     <Compile Include="SprintNumber.cs" />
     <Compile Include="StructuredBranch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Bluewire.Conventions/BranchSemantics.cs
+++ b/Bluewire.Conventions/BranchSemantics.cs
@@ -30,5 +30,25 @@ namespace Bluewire.Conventions
         {
             return types.Distinct().Select(t => t.BranchFilter).Where(b => !String.IsNullOrWhiteSpace(b)).Select(b => $"*/{b}").ToArray();
         }
+
+
+        // Assumes we always create a tag when we start a new version
+        public string GetVersionZeroBranchName(SemanticVersion semVer)
+        {
+            return string.Format("{0}.{1}", semVer.Major, semVer.Minor);
+        }
+
+        // Assumes sementics defined in BranchType.cs
+        public string GetVersionLatestBranchName(SemanticVersion semVer)
+        {
+            switch (semVer.SemanticTag)
+            {
+                case "beta": return "master";
+                case "rc": return string.Format("candidate/{0}.{1}", semVer.Major, semVer.Minor);
+                case "release": return string.Format("release/{0}.{1}", semVer.Major, semVer.Minor);
+                case "canary": return null;
+                default: throw new InvalidOperationException("Unknown semantic tag value");
+            }
+        }
     }
 }

--- a/Bluewire.Conventions/Patterns.cs
+++ b/Bluewire.Conventions/Patterns.cs
@@ -15,6 +15,16 @@ namespace Bluewire.Conventions
 $
 ", RegexOptions.IgnorePatternWhitespace | RegexOptions.IgnoreCase);
 
+        // Assumes year.sprint.build-semtag format where sprint is zero padded and never greater than 99, eg. 17.05.1234-rc
+        public static readonly Regex SemanticVersionStructure = new Regex(@"
+^
+(?<major>\d{2})\.
+(?<minor>\d{2})\.
+(?<build>\d+)
+(- (?<semtag>[A-Za-z]+))?
+$
+", RegexOptions.IgnorePatternWhitespace | RegexOptions.IgnoreCase);
+
         // Assumes YouTrack ticket identifier format, eg. E-23456
         public static readonly Regex TicketIdentifier = new Regex(@"\b[A-Z]{1,3}-\d{1,5}\b", RegexOptions.IgnoreCase);
 

--- a/Bluewire.Conventions/SemanticVersion.cs
+++ b/Bluewire.Conventions/SemanticVersion.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Text;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Bluewire.Conventions
+{
+    // major.minor.build-semtag
+    public class SemanticVersion
+    {
+        public readonly static string[] KnownSemanticTags = new string[4] { "beta", "rc", "release", "canary" };
+
+        public bool IsComplete
+        {
+            get
+            {
+                return !string.IsNullOrWhiteSpace(SemanticTag) && KnownSemanticTags.Contains(SemanticTag);
+            }
+        }
+
+        public SemanticVersion(string major, string minor, int build, string semanticTag)
+        {
+            Major = major;
+            Minor = minor;
+            Build = build;
+            SemanticTag = semanticTag;
+        }
+
+        public SemanticVersion(string versionNumber, int buildNumber, BranchType branchType)
+        {
+            var majorMinor = versionNumber.Split('.');
+            Major = majorMinor[0];
+            Minor = majorMinor[1];
+            Build = buildNumber;
+            SemanticTag = branchType.SemanticTag;
+        }
+        
+        public static SemanticVersion FromString(string semVer)
+        {
+            var m = Patterns.SemanticVersionStructure.Match(semVer);
+            if (!m.Success)
+            {
+                throw new ArgumentException($"Unable to parse semantic version: {semVer}");
+            }
+            
+            return new SemanticVersion(m.Groups["major"].Value, m.Groups["minor"].Value, int.Parse(m.Groups["build"].Value), m.Groups["semtag"]?.Value);
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendFormat("{0}.{1}.{2}", Major, Minor, Build);
+            if (!string.IsNullOrEmpty(SemanticTag)) sb.AppendFormat("-{0}", SemanticTag);
+            return sb.ToString();
+        }
+
+        public string Major { get; }
+        public string Minor { get; }
+        public int Build { get; }
+        public string SemanticTag { get; }
+
+        public static SemanticVersion FindEarliestSemanticTag(SemanticVersion[] originalVersions)
+        {
+            if (originalVersions.Length <= 0) throw new ArgumentException("No versions supplied.");
+
+            var betaVersion = originalVersions.Where(v => v.SemanticTag == "beta").SingleOrDefault();
+            if (betaVersion != null) return betaVersion;
+
+            var rcVersion = originalVersions.Where(v => v.SemanticTag == "rc").SingleOrDefault();
+            if (rcVersion != null) return rcVersion;
+
+            var releaseVersion = originalVersions.Where(v => v.SemanticTag == "release").SingleOrDefault();
+            if (releaseVersion != null) return releaseVersion;
+
+            throw new ArgumentException("No versions with a valid semantic tag supplied.");
+        }
+    }
+}

--- a/Bluewire.Tools.GitRepository.IntegrationTests/TopologicalBuildNumberResolverPerformanceTests.cs
+++ b/Bluewire.Tools.GitRepository.IntegrationTests/TopologicalBuildNumberResolverPerformanceTests.cs
@@ -36,7 +36,7 @@ namespace Bluewire.Tools.GitRepository.IntegrationTests
         [Test]
         public async Task BinarySearch()
         {
-            var sut = new TopologicalBuildNumberResolver(session, new TopologicalBuildNumberCalculator(session))
+            var sut = new TopologicalBuildNumberResolver(session)
             {
                 SearchImplementation = new TopologicalBuildNumberResolver.BinarySearcherImpl()
             };
@@ -49,7 +49,7 @@ namespace Bluewire.Tools.GitRepository.IntegrationTests
         [Test]
         public async Task LinearSearch()
         {
-            var sut = new TopologicalBuildNumberResolver(session, new TopologicalBuildNumberCalculator(session))
+            var sut = new TopologicalBuildNumberResolver(session)
             {
                 SearchImplementation = new TopologicalBuildNumberResolver.LinearSearcherImpl()
             };

--- a/Bluewire.Tools.GitRepository.IntegrationTests/TopologicalBuildNumberResolverTests.cs
+++ b/Bluewire.Tools.GitRepository.IntegrationTests/TopologicalBuildNumberResolverTests.cs
@@ -26,7 +26,7 @@ namespace Bluewire.Tools.GitRepository.IntegrationTests
             workingCopy = await session.Init(Default.TemporaryDirectory, "repository");
             await session.Commit(workingCopy, "Initial commit", CommitOptions.AllowEmptyCommit);
 
-            sut = new TopologicalBuildNumberResolver(session, new TopologicalBuildNumberCalculator(session));
+            sut = new TopologicalBuildNumberResolver(session);
             builder = new RepoStructureBuilder(session, workingCopy);
             startTag = await session.CreateTag(workingCopy, "start", Ref.Head, "");
             start = await session.ResolveRef(workingCopy, startTag);

--- a/Bluewire.Tools.GitRepository/TopologicalBuildNumberResolver.cs
+++ b/Bluewire.Tools.GitRepository/TopologicalBuildNumberResolver.cs
@@ -18,10 +18,10 @@ namespace Bluewire.Tools.GitRepository
 
         public ISearcher SearchImplementation { get; set; } = new BinarySearcherImpl();
 
-        public TopologicalBuildNumberResolver(GitSession session, TopologicalBuildNumberCalculator calculator)
+        public TopologicalBuildNumberResolver(GitSession session, TopologicalBuildNumberCalculator calculator = null)
         {
             this.session = session;
-            this.calculator = calculator;
+            this.calculator = calculator ?? new TopologicalBuildNumberCalculator(session);
         }
 
         public async Task<Ref> FindCommit(IGitFilesystemContext workingCopyOrRepo, Ref startRef, Ref endRef, int buildNumber)

--- a/Bluewire.Tools.Runner/Bluewire.Tools.Runner.csproj
+++ b/Bluewire.Tools.Runner/Bluewire.Tools.Runner.csproj
@@ -90,10 +90,15 @@
     <Compile Include="FindBuild\RepositoryStructureInspector.cs" />
     <Compile Include="FindBuild\ResolveBuildVersionsFromCommit.cs" />
     <Compile Include="FindBuild\ToolRunner.cs" />
+    <Compile Include="FindCommits\IBuildVersionResolutionJob.cs" />
+    <Compile Include="FindCommits\ResolveCommitFromSemanticVersion.cs" />
+    <Compile Include="FindCommits\ToolRunner.cs" />
     <Compile Include="GenerateScripts\ToolRunner.cs" />
     <Compile Include="IToolRunner.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Shared\Build.cs" />
+    <Compile Include="Shared\BuildUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Bluewire.Tools.Runner/Bluewire.Tools.Runner.csproj
+++ b/Bluewire.Tools.Runner/Bluewire.Tools.Runner.csproj
@@ -90,6 +90,9 @@
     <Compile Include="FindBuild\RepositoryStructureInspector.cs" />
     <Compile Include="FindBuild\ResolveBuildVersionsFromCommit.cs" />
     <Compile Include="FindBuild\ToolRunner.cs" />
+    <Compile Include="FindTickets\ITicketsResolutionJob.cs" />
+    <Compile Include="FindTickets\ResolveTicketsFromSemanticVersions.cs" />
+    <Compile Include="FindTickets\ToolRunner.cs" />
     <Compile Include="FindCommits\IBuildVersionResolutionJob.cs" />
     <Compile Include="FindCommits\ResolveCommitFromSemanticVersion.cs" />
     <Compile Include="FindCommits\ToolRunner.cs" />

--- a/Bluewire.Tools.Runner/FindBuild/IBuildVersionResolutionJob.cs
+++ b/Bluewire.Tools.Runner/FindBuild/IBuildVersionResolutionJob.cs
@@ -1,10 +1,11 @@
 ﻿using System.Threading.Tasks;
 using Bluewire.Common.GitWrapper;
+using Bluewire.Conventions;
 
 namespace Bluewire.Tools.Runner.FindBuild
 {
     public interface IBuildVersionResolutionJob
     {
-        Task<string[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository);
+        Task<SemanticVersion[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository);
     }
 }

--- a/Bluewire.Tools.Runner/FindBuild/ResolveBuildVersionsFromCommit.cs
+++ b/Bluewire.Tools.Runner/FindBuild/ResolveBuildVersionsFromCommit.cs
@@ -2,6 +2,7 @@
 using Bluewire.Common.Console;
 using Bluewire.Common.GitWrapper;
 using Bluewire.Common.GitWrapper.Model;
+using Bluewire.Conventions;
 
 namespace Bluewire.Tools.Runner.FindBuild
 {
@@ -14,7 +15,7 @@ namespace Bluewire.Tools.Runner.FindBuild
             this.commitRef = commitRef;
         }
 
-        public async Task<string[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository)
+        public async Task<SemanticVersion[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository)
         {
             var hash = await ResolveToHash(session, repository);
 

--- a/Bluewire.Tools.Runner/FindBuild/ResolveBuildVersionsFromGitHubPullRequest.cs
+++ b/Bluewire.Tools.Runner/FindBuild/ResolveBuildVersionsFromGitHubPullRequest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Bluewire.Common.Console;
 using Bluewire.Common.GitWrapper;
 using Bluewire.Common.GitWrapper.Model;
+using Bluewire.Conventions;
 
 namespace Bluewire.Tools.Runner.FindBuild
 {
@@ -16,7 +17,7 @@ namespace Bluewire.Tools.Runner.FindBuild
             this.pullRequestNumber = pullRequestNumber;
         }
 
-        public async Task<string[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository)
+        public async Task<SemanticVersion[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository)
         {
             var hash = await ResolveToSingleCommit(session, repository);
 

--- a/Bluewire.Tools.Runner/FindBuild/ResolveBuildVersionsFromTicketIdentifier.cs
+++ b/Bluewire.Tools.Runner/FindBuild/ResolveBuildVersionsFromTicketIdentifier.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Bluewire.Common.Console;
 using Bluewire.Common.GitWrapper;
 using Bluewire.Common.GitWrapper.Model;
+using Bluewire.Conventions;
 
 namespace Bluewire.Tools.Runner.FindBuild
 {
@@ -17,7 +18,7 @@ namespace Bluewire.Tools.Runner.FindBuild
             this.ticketIdentifier = ticketIdentifier;
         }
 
-        public async Task<string[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository)
+        public async Task<SemanticVersion[]> ResolveBuildVersions(GitSession session, Common.GitWrapper.GitRepository repository)
         {
             var hashes = await ResolveToHashes(session, repository);
 
@@ -39,7 +40,7 @@ namespace Bluewire.Tools.Runner.FindBuild
             var resolver = new TargetBranchResolver(session, repository);
             var finder = new BuildVersionFinder(session, repository);
 
-            var buildVersions = new List<string>();
+            var buildVersions = new List<SemanticVersion>();
             foreach (var hash in basemostHashes)
             {
                 var targetBranches = await resolver.IdentifyTargetBranchesOfCommit(hash);

--- a/Bluewire.Tools.Runner/FindBuild/ToolRunner.cs
+++ b/Bluewire.Tools.Runner/FindBuild/ToolRunner.cs
@@ -38,7 +38,9 @@ namespace Bluewire.Tools.Runner.FindBuild
             var options = CreateOptions(arguments);
             var sessionArgs = new SessionArguments<Arguments>(arguments, options);
             sessionArgs.Application += parentArgs;
-            return new ConsoleSession<Arguments>(sessionArgs).Run(args, async a => await new Impl(a).Run());
+            var consoleSession = new ConsoleSession<Arguments>(sessionArgs);
+            consoleSession.ListParameterUsage = "<identifier>";
+            return consoleSession.Run(args, async a => await new Impl(a).Run());
         }
 
         class Impl

--- a/Bluewire.Tools.Runner/FindCommits/IBuildVersionResolutionJob.cs
+++ b/Bluewire.Tools.Runner/FindCommits/IBuildVersionResolutionJob.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Bluewire.Common.GitWrapper;
+using Bluewire.Tools.Runner.Shared;
+
+namespace Bluewire.Tools.Runner.FindCommits
+{
+    public interface IBuildVersionResolutionJob
+    {
+        Task<Build[]> ResolveCommits(GitSession session, Common.GitWrapper.GitRepository repository);
+    }
+}

--- a/Bluewire.Tools.Runner/FindCommits/ResolveCommitFromSemanticVersion.cs
+++ b/Bluewire.Tools.Runner/FindCommits/ResolveCommitFromSemanticVersion.cs
@@ -1,0 +1,96 @@
+﻿using System.Threading.Tasks;
+using Bluewire.Common.GitWrapper;
+using Bluewire.Common.GitWrapper.Model;
+using Bluewire.Conventions;
+using Bluewire.Tools.GitRepository;
+using System.Collections.Generic;
+using Bluewire.Tools.Runner.Shared;
+using System;
+
+namespace Bluewire.Tools.Runner.FindCommits
+{
+    public class ResolveCommitFromSemanticVersion : IBuildVersionResolutionJob
+    {
+        private readonly SemanticVersion semVer;
+
+        public ResolveCommitFromSemanticVersion(string semVer)
+        {
+            this.semVer = SemanticVersion.FromString(semVer);
+        }
+        
+        public async Task<Build[]> ResolveCommits(GitSession session, Common.GitWrapper.GitRepository repository)
+        {
+
+            // We expect only BuildNumberOutOfRangeException and BuildNumberNotFoundException exceptions.
+            // The caller of this method could notify the user that no builds were found but doesn't need the specifics.
+
+            if (semVer.IsComplete)
+            {
+                try
+                {
+                    var commit = await FindRemoteCommit(session, repository, semVer);
+                    if (commit != null)
+                    {
+                        return new Build[1] { new Build() { Commit = commit, SemanticVersion = semVer } };
+                    }
+                }
+                catch (BuildNumberOutOfRangeException) { }
+                catch (BuildNumberNotFoundException) { }
+                return new Build[0];
+            }
+
+            var refs = new List<Build>(4);
+
+            foreach (string semTag in SemanticVersion.KnownSemanticTags)
+            {
+                var implicitSemVer = new SemanticVersion(semVer.Major, semVer.Minor, semVer.Build, semTag);
+                try
+                {
+                    var commit = await FindRemoteCommit(session, repository, implicitSemVer);
+                    if (commit != null)
+                    {
+                        refs.Add(new Build() { Commit = commit, SemanticVersion = implicitSemVer });
+                    }
+                }
+                catch (BuildNumberOutOfRangeException) { }
+                catch (BuildNumberNotFoundException) { }
+            }
+
+            if (refs.Count == 0) return new Build[0];
+
+            return BuildUtils.DeduplicateAndPrioritiseResult(refs.ToArray());
+        }
+
+        private async Task<Ref> FindRemoteCommit(GitSession session, IGitFilesystemContext repository, SemanticVersion semVer)
+        {
+            var resolver = new TopologicalBuildNumberResolver(session);
+            var branchSemantics = new BranchSemantics();
+
+            var startBranchName = new Ref(branchSemantics.GetVersionZeroBranchName(semVer));
+            var endLocalBranchName = branchSemantics.GetVersionLatestBranchName(semVer);
+            if (string.IsNullOrEmpty(endLocalBranchName) || string.IsNullOrEmpty(startBranchName)) return null;
+
+            var startRef = new Ref(startBranchName);
+            var endRef = await GetEndRef(session, repository, semVer, endLocalBranchName);
+
+            // It's less likely that the end ref will exist
+            if (!await session.RefExists(repository, endRef)) return null;
+            if (!await session.RefExists(repository, startRef)) return null;
+
+            return await resolver.FindCommit(repository, startRef, endRef, semVer.Build);
+        }
+
+        private static async Task<Ref> GetEndRef(GitSession session, IGitFilesystemContext repository, SemanticVersion semVer, string endLocalBranchName)
+        {
+            if (endLocalBranchName == "master")
+            {
+                var maintTag = new Ref($"tags/maint/{semVer.Major}.{semVer.Minor}");
+                if (await session.TagExists(repository, maintTag))
+                {
+                    return RefHelper.GetRemoteRef(new Ref(maintTag));
+                }
+            }
+            return RefHelper.GetRemoteRef(new Ref(endLocalBranchName));
+        }
+    }
+}

--- a/Bluewire.Tools.Runner/FindCommits/ToolRunner.cs
+++ b/Bluewire.Tools.Runner/FindCommits/ToolRunner.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Bluewire.Common.Console;
+using Bluewire.Common.Console.Logging;
+using Bluewire.Common.Console.ThirdParty;
+using Bluewire.Common.GitWrapper;
+using log4net.Core;
+using Bluewire.Tools.Runner.Shared;
+using Bluewire.Tools.Runner.FindBuild;
+using Bluewire.Conventions;
+
+namespace Bluewire.Tools.Runner.FindCommits
+{
+    public class ToolRunner : IToolRunner
+    {
+        public string Name => "find-commits";
+
+        public void Describe(TextWriter writer)
+        {
+            writer.WriteLine($"  {Name}: Find the commit hash(es) for the specified semantic version (release, build number and optional semantic tag).");
+        }
+
+        private static OptionSet CreateOptions(Arguments arguments)
+        {
+            return new OptionSet
+            {
+                {"s=|semver=", "Resolve a commit hash for a semantic version (<major>.<minor>.<build>[-semtag]). Omit the semtag if you want all semantic version tags to be searched.", o => arguments.Request(RequestType.SemanticVersion, o) },
+                {"repo=|repository=", "Specify the repository to use. Default: current directory.", o => arguments.WorkingCopyOrRepo = o}
+            };
+        }
+
+        public int RunMain(string[] args, string parentArgs)
+        {
+            var arguments = new Arguments();
+            var options = CreateOptions(arguments);
+            var sessionArgs = new SessionArguments<Arguments>(arguments, options);
+            sessionArgs.Application += parentArgs;
+            var consoleSession = new ConsoleSession<Arguments>(sessionArgs);
+            consoleSession.ListParameterUsage = "<semantic version>";
+            return consoleSession.Run(args, async a => await new Impl(a).Run());
+        }
+
+        class Impl
+        {
+            private readonly Arguments arguments;
+
+            public Impl(Arguments arguments)
+            {
+                this.arguments = arguments;
+
+                Log.Configure();
+                Log.SetConsoleVerbosity(arguments.Verbosity);
+            }
+
+            public async Task<int> Run()
+            {
+                TryInferArgumentsFromList(arguments);
+
+                var job = CreateJob(arguments);
+
+                var git = await new GitFinder().FromEnvironment();
+                var gitSession = new GitSession(git, new ConsoleInvocationLogger());
+
+                var gitRepository = GetGitRepository(arguments.WorkingCopyOrRepo);
+
+                var builds = await job.ResolveCommits(gitSession, gitRepository);
+
+                if (builds.Length == 0)
+                {
+                    Console.Error.WriteLine("No commits found for that build. Try running 'git fetch' to update your repo.");
+                    return 1;
+                }
+                else
+                {
+                    var originalBuilds = await FindOriginalBuildNumbers(builds, gitSession, gitRepository);
+                    var selectedBuilds = BuildUtils.DeduplicateAndPrioritiseResult(originalBuilds);
+                    foreach (var build in selectedBuilds)
+                    {
+                        Console.WriteLine(build);
+                    }
+                 }
+
+                return 0;
+            }
+
+            private async static Task<Build[]> FindOriginalBuildNumbers(Build[] builds, GitSession session, Common.GitWrapper.GitRepository repository)
+            {
+                List<Build> originalBuilds = new List<Build>();
+
+                // The actual build number to be rendered to the user needs to be calculated because otherwise builds
+                // that were originally built as beta will be marked as rc or release if those branches have since been created.
+                foreach (var build in builds)
+                {
+                    var originalBuildVersions = await new ResolveBuildVersionsFromCommit(build.Commit).ResolveBuildVersions(session, repository);
+                    originalBuilds.Add(new Build() { SemanticVersion = SemanticVersion.FindEarliestSemanticTag(originalBuildVersions), Commit = build.Commit});
+                }
+
+                return originalBuilds.ToArray();
+            }
+
+            private static void TryInferArgumentsFromList(Arguments arguments)
+            {
+                if (!arguments.ArgumentList.Any()) return;
+                if (arguments.RequestType != RequestType.None)
+                {
+                    Log.Console.Warn($"Excess arguments detected: {String.Join(" ", arguments.ArgumentList)}");
+                    return;
+                }
+                if (arguments.ArgumentList.Count > 1)
+                {
+                    Log.Console.Warn($"Excess arguments detected: {String.Join(" ", arguments.ArgumentList.Skip(1))}");
+                    // Continue parsing the first argument.
+                }
+
+                var unqualifiedArgument = arguments.ArgumentList.First().Trim();
+                
+                arguments.Request(RequestType.SemanticVersion, unqualifiedArgument);
+            }
+
+            private static IBuildVersionResolutionJob CreateJob(Arguments arguments)
+            {
+                switch (arguments.RequestType)
+                {
+                    case RequestType.SemanticVersion:
+                        Log.Console.Debug($"Resolving commit from semantic version {arguments.Identifier}");
+                        return new ResolveCommitFromSemanticVersion(arguments.Identifier);
+                }
+                throw new InvalidArgumentsException("Semantic version (--semver) must be specified.");
+            }
+
+            private static Common.GitWrapper.GitRepository GetGitRepository(string path)
+            {
+                try
+                {
+                    return Common.GitWrapper.GitRepository.Find(path);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidArgumentsException(ex);
+                }
+            }
+        }
+
+        public class Arguments : IVerbosityArgument, IArgumentList
+        {
+            private readonly IEnumerable<Level> logLevels = new List<Level> { Level.Warn, Level.Info, Level.Debug };
+            private int logLevel = 1;
+
+            public Level Verbosity => logLevels.ElementAtOrDefault(logLevel) ?? Level.All;
+
+            public void Verbose()
+            {
+                logLevel++;
+                LogInvocations = true;
+            }
+
+            public bool LogInvocations { get; private set; }
+
+            public RequestType RequestType { get; private set; }
+            public string Identifier { get; private set; }
+
+            public void Request(RequestType type, string identifier)
+            {
+                RequestType = type;
+                Identifier = identifier;
+            }
+
+            public string WorkingCopyOrRepo { get; set; } = Environment.CurrentDirectory;
+            public IList<string> ArgumentList { get; } = new List<string>();
+        }
+
+        public enum RequestType
+        {
+            None,
+            SemanticVersion
+        }
+    }
+}

--- a/Bluewire.Tools.Runner/FindTickets/ITicketsResolutionJob.cs
+++ b/Bluewire.Tools.Runner/FindTickets/ITicketsResolutionJob.cs
@@ -1,0 +1,10 @@
+﻿using Bluewire.Common.GitWrapper;
+using System.Threading.Tasks;
+
+namespace Bluewire.Tools.Runner.FindTickets
+{
+    public interface ITicketsResolutionJob
+    {
+        Task<string[]> ResolveTickets(GitSession session, Common.GitWrapper.GitRepository repository);
+    }
+}

--- a/Bluewire.Tools.Runner/FindTickets/ResolveTicketsFromSemanticVersions.cs
+++ b/Bluewire.Tools.Runner/FindTickets/ResolveTicketsFromSemanticVersions.cs
@@ -1,0 +1,40 @@
+﻿using Bluewire.Common.GitWrapper;
+using Bluewire.Common.GitWrapper.Model;
+using Bluewire.Conventions;
+using Bluewire.Tools.Runner.Shared;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Linq;
+using System;
+
+namespace Bluewire.Tools.Runner.FindTickets
+{
+    internal class ResolveTicketsBetweenRefs : ITicketsResolutionJob
+    {
+        private Ref startRef;
+        private Ref endRef;
+
+        public ResolveTicketsBetweenRefs(Ref startRef, Ref endRef)
+        {
+            this.startRef = startRef;
+            this.endRef = endRef;
+        }
+
+        public async Task<string[]> ResolveTickets(GitSession session, Common.GitWrapper.GitRepository repository)
+        {
+            if (string.IsNullOrEmpty(startRef?.ToString()))
+                throw new InvalidOperationException("Starting Ref (commit) must be supplied");
+            if (string.IsNullOrEmpty(endRef?.ToString()))
+                throw new InvalidOperationException("Ending Ref (commit) must be supplied");
+
+            var includeCommits = await session.ReadLog(repository, new LogOptions(), new Difference(startRef, endRef));
+            var excludeCommits = await session.ReadLog(repository, new LogOptions(), new Difference(endRef, startRef));
+
+            var includeTicketsStrings = includeCommits.SelectMany(c => Patterns.TicketIdentifier.Matches(c.Message).OfType<Match>().Select(m => m.Value));
+            var excludeTicketsStrings = excludeCommits.SelectMany(c => Patterns.TicketIdentifier.Matches(c.Message).OfType<Match>().Select(m => m.Value));
+
+            return includeTicketsStrings.Except(excludeTicketsStrings).ToArray();
+        }
+
+    }
+}

--- a/Bluewire.Tools.Runner/FindTickets/ToolRunner.cs
+++ b/Bluewire.Tools.Runner/FindTickets/ToolRunner.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Bluewire.Common.Console;
+using Bluewire.Common.Console.Logging;
+using Bluewire.Common.Console.ThirdParty;
+using Bluewire.Common.GitWrapper;
+using log4net.Core;
+using Bluewire.Common.GitWrapper.Model;
+using Bluewire.Conventions;
+using Bluewire.Tools.Runner.Shared;
+
+namespace Bluewire.Tools.Runner.FindTickets
+{
+    public class ToolRunner : IToolRunner
+    {
+        public string Name => "find-tickets";
+
+        public void Describe(TextWriter writer)
+        {
+            writer.WriteLine($"  {Name}: Find the tickets mentioned between two semantic versions (release, build number and optional semantic tag). Supply only one semantic version to produce a list of tickets to the head of the branch that build is found on.");
+        }
+
+        private static OptionSet CreateOptions(Arguments arguments)
+        {
+            return new OptionSet
+            {
+                {"s=|start-semver=", "Starting (lower) semantic version (<major>.<minor>.<build>[-semtag]). Omit the semtag if you want all semantic version tags to be searched for a match in this order: release, rc, beta.", o => arguments.StartSemanticVersion = o },
+                { "e=|end-semver=", "Ending (higher) semantic version (<major>.<minor>.<build>[-semtag]). Omit the semtag if you want all semantic version tags to be searched for a match in this order: release, rc, beta.", o => arguments.EndSemanticVersion = o },
+                {"repo=|repository=", "Specify the repository to use. Default: current directory.", o => arguments.WorkingCopyOrRepo = o}
+            };
+        }
+
+        public int RunMain(string[] args, string parentArgs)
+        {
+            var arguments = new Arguments();
+            var options = CreateOptions(arguments);
+            var sessionArgs = new SessionArguments<Arguments>(arguments, options);
+            sessionArgs.Application += parentArgs;
+            var consoleSession = new ConsoleSession<Arguments>(sessionArgs);
+            consoleSession.ListParameterUsage = "<from version> [to version]";
+            return consoleSession.Run(args, async a => await new Impl(a).Run());
+        }
+
+        class Impl
+        {
+            private readonly Arguments arguments;
+
+            public Impl(Arguments arguments)
+            {
+                this.arguments = arguments;
+
+                Log.Configure();
+                Log.SetConsoleVerbosity(arguments.Verbosity);
+            }
+
+            public async Task<int> Run()
+            {
+                TryInferArgumentsFromList(arguments);
+
+
+                var git = await new GitFinder().FromEnvironment();
+                var gitSession = new GitSession(git, new ConsoleInvocationLogger());
+                var gitRepository = GetGitRepository(arguments.WorkingCopyOrRepo);
+
+                var startCommitJob = new FindCommits.ResolveCommitFromSemanticVersion(arguments.StartSemanticVersion);
+                var startBuilds = await startCommitJob.ResolveCommits(gitSession, gitRepository);
+                if (startBuilds.Length > 1)
+                {
+                    Log.Console.Error("Ambiguous start build. Please supply a semantic tag.");
+                    return 1;
+                }
+                if (startBuilds.Length == 0)
+                {
+                    Log.Console.Error("Could not find start build. Please check it's correct and your repo is up to date.");
+                    return 2;
+                }
+                var startBuild = startBuilds[0];
+                Build endBuild;
+
+                if (!string.IsNullOrEmpty(arguments.EndSemanticVersion))
+                {
+                    var endCommitJob = new FindCommits.ResolveCommitFromSemanticVersion(arguments.EndSemanticVersion);
+                    var endBuilds = await endCommitJob.ResolveCommits(gitSession, gitRepository);
+                    if (endBuilds.Length > 1)
+                    {
+                        Log.Console.Error("Ambiguous end build. Please supply a semantic tag.");
+                        return 3;
+                    }
+                    if (endBuilds.Length == 0)
+                    {
+                        Log.Console.Error("Could not find end build. Please check it's correct and your repo is up to date.");
+                        return 4;
+                    }
+                    endBuild = endBuilds[0];
+                }
+                else
+                {
+                    var endCommit = await FindEndCommitFromStartBuild(gitSession, gitRepository, startBuild.SemanticVersion);
+                    endBuild = new Build() { Commit = endCommit, SemanticVersion = null };
+                }
+
+                Log.Console.Debug($"Finding tickets between semantic version {startBuild.SemanticVersion} and {endBuild.SemanticVersion?.ToString() ?? endBuild.Commit}");
+                var job = new ResolveTicketsBetweenRefs(startBuild.Commit, endBuild.Commit);
+                var tickets = await job.ResolveTickets(gitSession, gitRepository);                
+                RenderTickets(tickets);
+                return 0;
+            }
+
+            private static void RenderTickets(string[] tickets)
+            {
+                foreach (var ticket in tickets)
+                {
+                    Console.WriteLine(ticket);
+                }
+            }
+
+            private static void TryInferArgumentsFromList(Arguments arguments)
+            {
+                if (!arguments.ArgumentList.Any()) return;
+                if (arguments.ArgumentList.Count > 2)
+                {
+                    Log.Console.Warn($"Excess arguments detected: {string.Join(" ", arguments.ArgumentList.Skip(1))}");
+                    // Continue parsing the first two arguments.
+                }
+
+                arguments.StartSemanticVersion = arguments.ArgumentList.First().Trim();
+                arguments.EndSemanticVersion = arguments.ArgumentList.ElementAtOrDefault(1)?.Trim();
+            }
+            
+            private async Task<Ref> FindEndCommitFromStartBuild(GitSession session, Common.GitWrapper.GitRepository repository, SemanticVersion startSemanticVersion)
+            {
+                    var branchSemantics = new BranchSemantics();
+                    var refName = branchSemantics.GetVersionLatestBranchName(startSemanticVersion);
+                    if (refName == "master")
+                    {
+                        var maintTag = new Ref($"tags/maint/{startSemanticVersion.Major}.{startSemanticVersion.Minor}");
+                        if (await session.TagExists(repository, maintTag))
+                        {
+                            return maintTag;
+                        }
+                    }
+                    return RefHelper.GetRemoteRef(new Ref(refName));
+            }
+            
+            private static Common.GitWrapper.GitRepository GetGitRepository(string path)
+            {
+                try
+                {
+                    return Common.GitWrapper.GitRepository.Find(path);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidArgumentsException(ex);
+                }
+            }
+        }
+
+        public class Arguments : IVerbosityArgument, IArgumentList
+        {
+            private readonly IEnumerable<Level> logLevels = new List<Level> { Level.Warn, Level.Info, Level.Debug };
+            private int logLevel = 1;
+
+            public Level Verbosity => logLevels.ElementAtOrDefault(logLevel) ?? Level.All;
+
+            public void Verbose()
+            {
+                logLevel++;
+                LogInvocations = true;
+            }
+
+            public bool LogInvocations { get; private set; }
+
+            public string StartSemanticVersion { get; set; }
+            public string EndSemanticVersion { get; set; }
+
+            public string WorkingCopyOrRepo { get; set; } = Environment.CurrentDirectory;
+            public IList<string> ArgumentList { get; } = new List<string>();
+        }
+    }
+}

--- a/Bluewire.Tools.Runner/Program.cs
+++ b/Bluewire.Tools.Runner/Program.cs
@@ -87,7 +87,8 @@ namespace Bluewire.Tools.Runner
         {
             var tools = new List<IToolRunner>
             {
-                new FindBuild.ToolRunner()
+                new FindBuild.ToolRunner(),
+                new FindCommits.ToolRunner()
             };
 
             var generateScripts = new GenerateScripts.ToolRunner(tools.Select(t => t.Name).ToArray());

--- a/Bluewire.Tools.Runner/Program.cs
+++ b/Bluewire.Tools.Runner/Program.cs
@@ -88,7 +88,8 @@ namespace Bluewire.Tools.Runner
             var tools = new List<IToolRunner>
             {
                 new FindBuild.ToolRunner(),
-                new FindCommits.ToolRunner()
+                new FindCommits.ToolRunner(),
+                new FindTickets.ToolRunner()
             };
 
             var generateScripts = new GenerateScripts.ToolRunner(tools.Select(t => t.Name).ToArray());

--- a/Bluewire.Tools.Runner/Shared/Build.cs
+++ b/Bluewire.Tools.Runner/Shared/Build.cs
@@ -1,0 +1,23 @@
+﻿using Bluewire.Common.GitWrapper.Model;
+using Bluewire.Conventions;
+
+namespace Bluewire.Tools.Runner.Shared
+{
+    public struct Build
+    {
+        /// <summary>
+        /// Commit hash
+        /// </summary>
+        public Ref Commit { get; set; }
+
+        /// <summary>
+        /// Semantic version representing the location of the Commit in the git tree
+        /// </summary>
+        public SemanticVersion SemanticVersion { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("{0} {1}", Commit.ToString(), SemanticVersion.ToString());
+        }
+    }
+}

--- a/Bluewire.Tools.Runner/Shared/BuildUtils.cs
+++ b/Bluewire.Tools.Runner/Shared/BuildUtils.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bluewire.Tools.Runner.Shared
+{
+    public class BuildUtils
+    {
+        public static Build[] DeduplicateAndPrioritiseResult(Build[] builds)
+        {
+            if (builds.Length <= 0) throw new ArgumentException("No build results supplied.");
+
+            var selectedBuilds = new List<Build>();
+
+            foreach (var commit in builds.GroupBy(b => b.Commit))
+            {
+                var releaseBuild = commit.Where(build => build.SemanticVersion.SemanticTag == "release").FirstOrDefault();
+                if (releaseBuild.SemanticVersion != null)
+                {
+                    selectedBuilds.Add(releaseBuild);
+                    continue;
+                }
+                var rcBuild = commit.Where(build => build.SemanticVersion.SemanticTag == "rc").FirstOrDefault();
+                if (rcBuild.SemanticVersion != null)
+                {
+                    selectedBuilds.Add(rcBuild);
+                    continue;
+                }
+                var betaBuild = commit.Where(build => build.SemanticVersion.SemanticTag == "beta").FirstOrDefault();
+                if (betaBuild.SemanticVersion != null)
+                {
+                    selectedBuilds.Add(betaBuild);
+                    continue;
+                }
+            }
+
+            return selectedBuilds.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
I've not actually got to the "find ticket numbers" part yet but it's probably worth a review at this intermediate point. Consider it WIP despite that not being part of the workflow for this repo.

I've had to depend on Bluewire.Common.GitWrapper in the Conventions in order to be able to work with Refs rather than strings which I think is a reasonable tradeoff but let me know if you disagree.