### PR TITLE
Fix construction of URIs for local repositories

### DIFF
--- a/Bluewire.Common.GitWrapper.IntegrationTests/Bluewire.Common.GitWrapper.IntegrationTests.csproj
+++ b/Bluewire.Common.GitWrapper.IntegrationTests/Bluewire.Common.GitWrapper.IntegrationTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="GitListCommitsBetweenTests.cs" />
     <Compile Include="GitLogTests.cs" />
     <Compile Include="GitMergeBaseTests.cs" />
+    <Compile Include="GitRepositoryTests.cs" />
     <Compile Include="GitTagTests.cs" />
     <Compile Include="GitBranchTests.cs" />
     <Compile Include="GitDetectionTests.cs" />

--- a/Bluewire.Common.GitWrapper.IntegrationTests/GitRepositoryTests.cs
+++ b/Bluewire.Common.GitWrapper.IntegrationTests/GitRepositoryTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Bluewire.Common.GitWrapper.IntegrationTests
+{
+    [TestFixture]
+    public class GitRepositoryTests
+    {
+        [Test]
+        public async Task GetLocationUriCreatesCorrectUriForLocalPath()
+        {
+            var session = await Default.GitSession();
+            var workingCopy = await session.Init(Default.TemporaryDirectory, "repository");
+            var repository = workingCopy.GetDefaultRepository();
+
+            var localPath = workingCopy.Root;
+            // Expect something like 'file:///<drive>:/<working-copy-path>/.git'
+            var expectedUri = new Uri($"file:///{localPath.Replace(Path.DirectorySeparatorChar, '/')}/.git");
+
+            Assert.That(repository.GetLocationUri(), Is.EqualTo(expectedUri));
+        }
+    }
+}

--- a/Bluewire.Common.GitWrapper/GitRepository.cs
+++ b/Bluewire.Common.GitWrapper/GitRepository.cs
@@ -26,7 +26,7 @@ namespace Bluewire.Common.GitWrapper
 
         public Uri GetLocationUri()
         {
-            return new UriBuilder { Scheme = "file", Path = Location }.Uri;
+            return new UriBuilder { Scheme = "file", Host = "", Path = Location }.Uri;
         }
 
         public static GitRepository Find(string path)

--- a/Bluewire.Common.GitWrapper/Properties/AssemblyInfo.cs
+++ b/Bluewire.Common.GitWrapper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.1.1")]
+[assembly: AssemblyFileVersion("2.1.1")]


### PR DESCRIPTION
Bluewire.Common.GitWrapper: 2.1.0 -> 2.1.1