### PR TITLE
Do not try to query for 'empty' parent ticket keys

### DIFF
--- a/CanaryCollector/Remote/Jira/JiraTicketProvider.cs
+++ b/CanaryCollector/Remote/Jira/JiraTicketProvider.cs
@@ -22,7 +22,7 @@ namespace CanaryCollector.Remote.Jira
         {
             var linearWorkflowIssues = GetLinearWorkflowIssues().Take(500).ToArray();
             var pullRequests = GetIncompletePullRequests().Take(500).ToArray();
-            var pullRequestParents = await jira.Issues.GetIssuesAsync(pullRequests.Select(s => s.ParentIssueKey).Distinct());
+            var pullRequestParents = await jira.Issues.GetIssuesAsync(pullRequests.Select(s => s.ParentIssueKey).Where(k => !String.IsNullOrWhiteSpace(k)).Distinct());
 
             return linearWorkflowIssues.Concat(pullRequestParents.Values).Select(ReadTicket).ToArray();
         }


### PR DESCRIPTION
A PR ticket which lacks a parent will cause an empty string to be
included in the collection passed to GetIssuesAsync, which will generate
invalid JQL.

refs S-5773