### PR TITLE
Protect backport branches against pruning

### DIFF
--- a/RefCleaner/Collectors/KeepAllReleaseBranches.cs
+++ b/RefCleaner/Collectors/KeepAllReleaseBranches.cs
@@ -33,6 +33,10 @@ namespace RefCleaner.Collectors
             {
                 details.UpdateDisposition(BranchDisposition.MustKeep);
             }
+            if (structured.Namespace.Split('/').Contains("backport", StringComparer.OrdinalIgnoreCase))
+            {
+                details.UpdateDisposition(BranchDisposition.MustKeep);
+            }
         }
     }
 }


### PR DESCRIPTION
Afford these the same protection granted to release and candidate
branches.