### PR TITLE
Fix recursive GC of pending transactions

### DIFF
--- a/Bluewire.Stash.IntegrationTests/Tool/BackgroundGCTests.cs
+++ b/Bluewire.Stash.IntegrationTests/Tool/BackgroundGCTests.cs
@@ -1,0 +1,48 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Bluewire.Common.Console.NUnit3.Filesystem;
+using Bluewire.Stash.Tool;
+using NUnit.Framework;
+
+namespace Bluewire.Stash.IntegrationTests.Tool
+{
+    [TestFixture]
+    public class BackgroundGCTests
+    {
+        [Test]
+        public async Task DoesNotRemoveLockedTransactions()
+        {
+            var stashRepository = new LocalStashRepository(Path.Combine(TemporaryDirectory.ForCurrentTest(), ".stashes"));
+            using (var stash = await stashRepository.GetOrCreateExact(new VersionMarker("some-hash")))
+            {
+                await stash.Store(new MemoryStream(), "testfile");
+
+                await new GarbageCollection(new VerboseLogger(TextWriter.Null, 0)).RunAndWait(stashRepository);
+
+                await stash.Commit();
+
+                var items = await stash.List().ToListAsync();
+                Assert.That(items, Does.Contain("testfile"));
+            }
+        }
+
+        [Test]
+        public async Task DoesNotRemoveStashes()
+        {
+            var stashRepository = new LocalStashRepository(Path.Combine(TemporaryDirectory.ForCurrentTest(), ".stashes"));
+            using (var stash = await stashRepository.GetOrCreateExact(new VersionMarker("some-hash")))
+            {
+                await stash.Store(new MemoryStream(), "testfile");
+                await stash.Commit();
+            }
+
+            await new GarbageCollection(new VerboseLogger(TextWriter.Null, 0)).RunAndWait(stashRepository);
+
+            using (var stash = await stashRepository.GetOrCreateExact(new VersionMarker("some-hash")))
+            {
+                var items = await stash.List().ToListAsync();
+                Assert.That(items, Does.Contain("testfile"));
+            }
+        }
+    }
+}

--- a/Bluewire.Stash.Tool/CheckoutCommand.cs
+++ b/Bluewire.Stash.Tool/CheckoutCommand.cs
@@ -22,7 +22,7 @@ namespace Bluewire.Stash.Tool
 
             if (LocalFileSystem.DirectoryExists(model.DestinationPath.Value))
             {
-                await foreach (var _ in LocalFileSystem.EnumerateRelativePaths(model.DestinationPath.Value).WithCancellation(token))
+                await foreach (var _ in LocalFileSystem.EnumerateRelativePaths(model.DestinationPath.Value, true).WithCancellation(token))
                 {
                     throw new Exception($"Directory exists and is not empty: {model.DestinationPath.Value}");
                 }

--- a/Bluewire.Stash.Tool/CommitCommand.cs
+++ b/Bluewire.Stash.Tool/CommitCommand.cs
@@ -38,7 +38,7 @@ namespace Bluewire.Stash.Tool
 
             using (var stash = await services.StashRepository.GetOrCreateExact(targetMarker))
             {
-                await foreach (var relativePath in LocalFileSystem.EnumerateRelativePaths(model.SourcePath.Value).WithCancellation(token))
+                await foreach (var relativePath in LocalFileSystem.EnumerateRelativePaths(model.SourcePath.Value, true).WithCancellation(token))
                 {
                     var absolutePath = Path.Combine(model.SourcePath.Value, relativePath);
                     using (var stream = LocalFileSystem.OpenForRead(absolutePath))

--- a/Bluewire.Stash.Tool/GarbageCollection.cs
+++ b/Bluewire.Stash.Tool/GarbageCollection.cs
@@ -20,6 +20,12 @@ namespace Bluewire.Stash.Tool
             return job;
         }
 
+        public async Task RunAndWait(ILocalStashRepository repository)
+        {
+            var job = new GCJob(repository, logger);
+            await job.Start();
+        }
+
         class GCJob : IDisposable
         {
             private readonly ILocalStashRepository repository;

--- a/Bluewire.Stash/LocalFileSystem.cs
+++ b/Bluewire.Stash/LocalFileSystem.cs
@@ -168,25 +168,25 @@ namespace Bluewire.Stash
             }
         }
 
-        public async IAsyncEnumerable<string> EnumerateAbsolutePaths(string rootPath)
+        public async IAsyncEnumerable<string> EnumerateAbsolutePaths(string rootPath, bool recursive)
         {
             // Could probably accept a glob argument as well in future, and use FlexiGlob for walking the hierarchy.
 
             var container = new DirectoryInfo(ValidateFullPath(rootPath, nameof(rootPath)));
             if (!container.Exists) yield break;
-            foreach (var file in container.EnumerateFiles("*", SearchOption.AllDirectories))
+            foreach (var file in container.EnumerateFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly))
             {
                 yield return file.FullName;
             }
         }
 
-        public async IAsyncEnumerable<string> EnumerateRelativePaths(string rootPath)
+        public async IAsyncEnumerable<string> EnumerateRelativePaths(string rootPath, bool recursive)
         {
             // Could probably accept a glob argument as well in future, and use FlexiGlob for walking the hierarchy.
 
             var container = new DirectoryInfo(ValidateFullPath(rootPath, nameof(rootPath)));
             if (!container.Exists) yield break;
-            foreach (var file in container.EnumerateFiles("*", SearchOption.AllDirectories))
+            foreach (var file in container.EnumerateFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly))
             {
                 yield return GetRelativePath(file, container);
             }

--- a/Bluewire.Stash/LocalStash.cs
+++ b/Bluewire.Stash/LocalStash.cs
@@ -145,7 +145,7 @@ namespace Bluewire.Stash
 
         public IAsyncEnumerable<string> List(CancellationToken token = default)
         {
-            return LocalFileSystem.EnumerateRelativePaths(finalPath);
+            return LocalFileSystem.EnumerateRelativePaths(finalPath, true);
         }
 
         public async Task Delete()

--- a/Bluewire.Stash/LocalStashRepository.cs
+++ b/Bluewire.Stash/LocalStashRepository.cs
@@ -203,7 +203,7 @@ namespace Bluewire.Stash
 
         public async IAsyncEnumerable<string> CleanUpTemporaryObjects([EnumeratorCancellation] CancellationToken token)
         {
-            await foreach (var path in LocalFileSystem.EnumerateAbsolutePaths(StashTemporaryDirectory).WithCancellation(token))
+            await foreach (var path in LocalFileSystem.EnumerateAbsolutePaths(StashTemporaryDirectory, false).WithCancellation(token))
             {
                 if (await TryCleanUp(path))
                 {
@@ -212,7 +212,7 @@ namespace Bluewire.Stash
             }
         }
 
-        [DebuggerNonUserCode]
+        //[DebuggerNonUserCode]
         private async Task<bool> TryCleanUp(string tempPath)
         {
             try

--- a/Bluewire.Stash/Remote/FileSystemStashRepository.cs
+++ b/Bluewire.Stash/Remote/FileSystemStashRepository.cs
@@ -63,7 +63,7 @@ namespace Bluewire.Stash.Remote
         public IAsyncEnumerable<string> ListFiles(VersionMarker entry, CancellationToken token = default)
         {
             var queryPath = GetEntryPath(entry);
-            return LocalFileSystem.EnumerateRelativePaths(queryPath);
+            return LocalFileSystem.EnumerateRelativePaths(queryPath, true);
         }
 
         public async Task<bool> Exists(VersionMarker entry, CancellationToken token = default)

--- a/Bluewire.Stash/Remote/RemoteStashRepositoryService.cs
+++ b/Bluewire.Stash/Remote/RemoteStashRepositoryService.cs
@@ -33,7 +33,7 @@ namespace Bluewire.Stash.Remote
         public async IAsyncEnumerable<string> CleanUpTemporaryObjects(IBlobCleaner blobCleaner, [EnumeratorCancellation] CancellationToken token)
         {
             var maxAge = TimeSpan.FromHours(4);
-            await foreach (var path in LocalFileSystem.EnumerateAbsolutePaths(GetTempPath()).WithCancellation(token))
+            await foreach (var path in LocalFileSystem.EnumerateAbsolutePaths(GetTempPath(), false).WithCancellation(token))
             {
                 var info = await LocalFileSystem.GetInfo(path);
                 if (info == null) continue;
@@ -63,7 +63,7 @@ namespace Bluewire.Stash.Remote
                 {
                     // Pending transaction. Clean up referenced blobs before deleting files.
                     var anyFailures = false;
-                    await foreach (var subPath in LocalFileSystem.EnumerateAbsolutePaths(tempPath))
+                    await foreach (var subPath in LocalFileSystem.EnumerateAbsolutePaths(tempPath, true))
                     {
                         if (!LocalFileSystem.FileExists(subPath)) continue;    // Directory.
                         if (await blobCleaner.TryCleanUp(LocalFileSystem, subPath))


### PR DESCRIPTION
A directory must be locked before it can be cleaned. Recursive
exploration will remove all files within it before trying to lock it.

refs EP-42861