### PR TITLE
Move default stash location to AppData/Local

### DIFF
--- a/Bluewire.Conventions.UnitTests/Bluewire.Conventions.UnitTests.csproj
+++ b/Bluewire.Conventions.UnitTests/Bluewire.Conventions.UnitTests.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\Bluewire.Conventions\Bluewire.Conventions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2020.1.3">
+    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2021.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Bluewire.Stash.IntegrationTests/Tool/AppEnvironmentTests.cs
+++ b/Bluewire.Stash.IntegrationTests/Tool/AppEnvironmentTests.cs
@@ -74,10 +74,11 @@ namespace Bluewire.Stash.IntegrationTests.Tool
         }
 
         [Test]
-        public void UsesTemporaryDirectoryStashRootIfNoEnvironmentVariableOrArgumentIsSpecified()
+        public void UsesUserDataDirectoryStashRootIfNoEnvironmentVariableOrArgumentIsSpecified()
         {
             var application = Mock.Of<StubApplication>(a =>
                     a.GetTemporaryDirectory() == @"c:\temp" &&
+                    a.GetUserDataDirectory() == @"c:\Users\someone\AppData\Local\Bluewire.Stash.Tool" &&
                     a.GetEnvironmentVariable("STASH_ROOT") == null)
                 .CallBase();
 
@@ -86,7 +87,7 @@ namespace Bluewire.Stash.IntegrationTests.Tool
 
             var model = application.Invocations.OfType<DiagnosticsArguments>().SingleOrDefault();
             Assert.That(model, Is.Not.Null);
-            Assert.That(model!.AppEnvironment.StashRoot, Is.EqualTo(new ArgumentValue<string>(@"c:\temp\.stashes\", ArgumentSource.Default)));
+            Assert.That(model!.AppEnvironment.StashRoot, Is.EqualTo(new ArgumentValue<string>(@"c:\Users\someone\AppData\Local\Bluewire.Stash.Tool\.stashes\", ArgumentSource.Default)));
         }
 
         [Test]

--- a/Bluewire.Stash.IntegrationTests/Tool/StubApplication.cs
+++ b/Bluewire.Stash.IntegrationTests/Tool/StubApplication.cs
@@ -10,6 +10,7 @@ namespace Bluewire.Stash.IntegrationTests.Tool
     {
         public virtual string GetCurrentDirectory() => @"z:\not set";
         public virtual string GetTemporaryDirectory() => @"z:\not set";
+        public virtual string GetUserDataDirectory() => @"z:\not set";
         public virtual string? GetEnvironmentVariable(string name) => @"z:\not set";
 
         public async Task ShowDiagnostics(TextWriter stdout, DiagnosticsArguments model, CancellationToken token) => Invocations.Add(model);

--- a/Bluewire.Stash.Tool/ArgumentsProvider.cs
+++ b/Bluewire.Stash.Tool/ArgumentsProvider.cs
@@ -44,7 +44,7 @@ namespace Bluewire.Stash.Tool
             if (cliValue != null) return new ArgumentValue<string>(EnsureTrailingSlash(cliValue), ArgumentSource.Argument);
             var envValue = application.GetEnvironmentVariable("STASH_ROOT");
             if (envValue != null) return new ArgumentValue<string>(EnsureTrailingSlash(envValue), ArgumentSource.Environment);
-            var defaultValue = Path.Combine(application.GetTemporaryDirectory(), ".stashes");
+            var defaultValue = Path.Combine(application.GetUserDataDirectory(), ".stashes");
             return new ArgumentValue<string>(EnsureTrailingSlash(defaultValue), ArgumentSource.Default);
         }
 

--- a/Bluewire.Stash.Tool/IApplication.cs
+++ b/Bluewire.Stash.Tool/IApplication.cs
@@ -8,6 +8,7 @@ namespace Bluewire.Stash.Tool
     {
         string GetCurrentDirectory();
         string GetTemporaryDirectory();
+        string GetUserDataDirectory();
         string? GetEnvironmentVariable(string name);
         Task ShowDiagnostics(TextWriter stdout, DiagnosticsArguments model, CancellationToken token);
         Task Authenticate(TextWriter stdout, AuthenticateArguments model, CancellationToken token);

--- a/Bluewire.Stash.Tool/Program.cs
+++ b/Bluewire.Stash.Tool/Program.cs
@@ -43,7 +43,7 @@ namespace Bluewire.Stash.Tool
                 o => o.Inherited = true);
 
             var stashRootOption = app.Option<string>("-S|--stash-root <path>",
-                "Directory in which local stashes should be kept. By default, uses the environment variable STASH_ROOT or %TEMP%/.stash.",
+                "Directory in which local stashes should be kept. By default, uses the environment variable STASH_ROOT or %LOCALAPPDATA%/Bluewire.Stash.Tool/.stashes.",
                 CommandOptionType.SingleValue,
                 o => o.Inherited = true);
 
@@ -262,6 +262,7 @@ namespace Bluewire.Stash.Tool
         {
             public string GetCurrentDirectory() => Directory.GetCurrentDirectory();
             public string GetTemporaryDirectory() => Path.GetTempPath();
+            public string GetUserDataDirectory() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Bluewire.Stash.Tool");
             public string? GetEnvironmentVariable(string name) => Environment.GetEnvironmentVariable(name);
 
             public async Task ShowDiagnostics(TextWriter stdout, DiagnosticsArguments model, CancellationToken token)

--- a/Bluewire.Stash.UnitTests/Bluewire.Stash.UnitTests.csproj
+++ b/Bluewire.Stash.UnitTests/Bluewire.Stash.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2020.1.3">
+    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2021.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
The user's temporary directory may occasionally be pruned by Windows in
ways which break the stash.

refs EP-42962