### PR TITLE
Treat LF characters as line endings in Git output

### DIFF
--- a/Bluewire.Common.GitWrapper.IntegrationTests/GitLogTests.cs
+++ b/Bluewire.Common.GitWrapper.IntegrationTests/GitLogTests.cs
@@ -50,6 +50,26 @@ with whitespace lines too.
         }
 
         [Test]
+        public async Task CanParseLogMessagesContainingCarriageReturns()
+        {
+            var message = $@"Test commit
+
+Multiple line{'\x0d'} commit message
+";
+            await session.Commit(workingCopy, message, CommitOptions.AllowEmptyCommit);
+            var commitHash = await session.ResolveRef(workingCopy, Ref.Head);
+
+            var logEntries = await session.ReadLog(workingCopy, new LogOptions(), Ref.Head);
+
+            var logEntry = logEntries.Single();
+
+            Assert.That(logEntry.Ref, Is.EqualTo(commitHash));
+            Assert.That(logEntry.Author, Is.Not.Null);
+            Assert.That(logEntry.Date, Is.Not.Null);
+            Assert.That(logEntry.Message, Is.EqualTo(message));
+        }
+
+        [Test]
         public async Task LogEntriesAreReturnedInInverseCommitOrder()
         {
             await session.Commit(workingCopy, "first commit", CommitOptions.AllowEmptyCommit);

--- a/Bluewire.Common.GitWrapper/Bluewire.Common.GitWrapper.csproj
+++ b/Bluewire.Common.GitWrapper/Bluewire.Common.GitWrapper.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="VersionPrefix">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <VersionPrefix>5.0.2</VersionPrefix>
+    <VersionPrefix>5.1.2</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/Bluewire.Common.GitWrapper/GitAsyncUnixOutputParserAdapter.cs
+++ b/Bluewire.Common.GitWrapper/GitAsyncUnixOutputParserAdapter.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bluewire.Common.GitWrapper
+{
+    /// <summary>
+    /// Parse output from Git, treating only LF as the line-break character.
+    /// </summary>
+    public class GitAsyncUnixOutputParserAdapter
+    {
+        private readonly Encoding encoding;
+
+        public GitAsyncUnixOutputParserAdapter(Encoding encoding)
+        {
+            this.encoding = encoding;
+        }
+
+        public async IAsyncEnumerator<string> Parse(Stream stream, CancellationToken token)
+        {
+            var buffer = new char[4096];
+            var line = new StringBuilder();
+            using (var reader = new StreamReader(stream, encoding))
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var count = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+                    if (count == 0) break;  // EOS
+
+                    for (var i = 0; i < count; i++)
+                    {
+                        var c = buffer[i];
+                        // Only treat line feeds as newline characters.
+                        if (c == '\n')
+                        {
+                            yield return line.ToString();
+                            line.Clear();
+                            continue;
+                        }
+                        line.Append(c);
+                    }
+                }
+                if (line.Length > 0) yield return line.ToString();
+            }
+            token.ThrowIfCancellationRequested();
+        }
+
+        public async Task CollectLines(Stream stream, Action<string> collectLine, CancellationToken token)
+        {
+            var enumerator = Parse(stream, token);
+            await using (enumerator.ConfigureAwait(false))
+            {
+                while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    collectLine(enumerator.Current);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Lone CR characters MUST NOT be treated as line breaks.
* CRLF sequences MUST be treated as a line ending with a single CR.

refs EP-49067