### PR TITLE
Implement aggressive cleanup mode

### DIFF
--- a/RefCleaner/Program.cs
+++ b/RefCleaner/Program.cs
@@ -41,7 +41,7 @@ namespace RefCleaner
 
         private async Task<int> Run()
         {
-            var factory = new RefCollectorFactory(RepositoryPath, RemoteName, Log.Console.IsDebugEnabled ? new ConsoleInvocationLogger() : null);
+            var factory = new RefCollectorFactory(RepositoryPath, RemoteName, Log.Console.IsDebugEnabled ? new ConsoleInvocationLogger() : null) { Aggressive = Aggressive };
 
             var collectors = new List<IRefCollector>
             {

--- a/RefCleaner/RefCollectorFactory.cs
+++ b/RefCleaner/RefCollectorFactory.cs
@@ -14,6 +14,8 @@ namespace RefCleaner
         private readonly string repositoryPath;
         private readonly string remoteName;
 
+        public bool Aggressive { get; set; }
+
         public RefCollectorFactory(string repositoryPath, string remoteName, IConsoleInvocationLogger logger = null)
         {
             this.repositoryPath = repositoryPath;
@@ -62,7 +64,7 @@ namespace RefCleaner
             yield return new KeepAllReleaseBranches();
             yield return new KeepAllPersonalBranches();
             yield return new KeepRecentBranches(DateTimeOffset.Now.AddMonths(-1));
-            yield return new DiscardMergedBranches(new MergedBranchTester(branchProvider));
+            yield return new DiscardMergedBranches(new MergedBranchTester(branchProvider), Aggressive);
         }
 
         private readonly Lazy<Task<GitSession>> sharedGitSession;


### PR DESCRIPTION
Treat a branch as 'merged' if it's in the backport branch, instead of waiting for it to reach the release branch.

refs EP-52933